### PR TITLE
Fix php8.2 deprecated warning

### DIFF
--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -112,6 +112,16 @@ abstract class BridgeAbstract implements BridgeInterface
      * @var string
      */
     protected $queriedContext = '';
+    
+    /**
+     * Holds the list of bridge-specific configurations from config.ini.php, used by the bridge.
+     *
+     * Do not access this parameter directly!
+     * Use {@see BridgeAbstract::getConfiguration()} and {@see BridgeAbstract::getOption(string $name)} instead.
+     *
+     * @var array
+     */
+    protected array $configuration = [];
 
     /** {@inheritdoc} */
     public function getItems()


### PR DESCRIPTION
Fixes the php8.2 warning:
```
(shutdown) 8192: Creation of dynamic property customBridge::$configuration is deprecated in lib/BridgeAbstract.php line 272
```